### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This action runs [regal](https://docs.styra.com/regal) with [reviewdog](https://
 
 ## Input
 
+<!-- markdownlint-disable MD013 -->
 ```yaml
 inputs:
   github_token:
@@ -61,6 +62,7 @@ inputs:
     description: 'Additional regal lint flags'
     default: ''
 ```
+<!-- markdownlint-enable MD013 -->
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This action runs [regal](https://docs.styra.com/regal) with [reviewdog](https://
 
 ## Input
 
-<!-- markdownlint-disable MD013 -->
 ```yaml
 inputs:
   github_token:
@@ -62,7 +61,6 @@ inputs:
     description: 'Additional regal lint flags'
     default: ''
 ```
-<!-- markdownlint-enable MD013 -->
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -n "${GITHUB_WORKSPACE}" ] ; then
   git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
 fi
 
-wget -O /usr/local/bin/regal -q "https://github.com/StyraInc/regal/releases/download/"${INPUT_REGAL_VERSION}"/regal_Linux_x86_64" \
+wget -O /usr/local/bin/regal -q "https://github.com/StyraInc/regal/releases/download/${INPUT_REGAL_VERSION}/regal_Linux_x86_64" \
     && chmod +x /usr/local/bin/regal
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ regal lint "${INPUT_POLICY_PATH}" ${INPUT_REGAL_FLAGS} -f json \
       -name="regal" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.